### PR TITLE
fix(conn.go): fixed decodeMap link

### DIFF
--- a/internal/conn.go
+++ b/internal/conn.go
@@ -29,7 +29,7 @@ const (
 	packetDecodeNotNeeded
 )
 
-//go:linkname decodeMap spectrum.decodeMap
+//go:linkname decodeMap github.com/cooldogedev/spectrum-df/util.decodeMap
 var decodeMap map[uint32]bool
 
 type Conn struct {


### PR DESCRIPTION
Apparently, decodemap wasn't linked correctly before causing issues with tracker.go. It should work correctly now.